### PR TITLE
Fix TM_SVN_DIFF_CMD support

### DIFF
--- a/Support/lib/subversion.rb
+++ b/Support/lib/subversion.rb
@@ -116,7 +116,7 @@ module Subversion
         end
       end
       differ = Proc.new do
-        Dir.chdir(base) { Subversion.run("diff", "-r", revision, *files) }
+        Dir.chdir(base) { Subversion.run("diff", (ENV['TM_SVN_DIFF_CMD'] ? "--diff-cmd=#{ENV['TM_SVN_DIFF_CMD']}" : ''), "-r", revision, *files) }
       end
       if revision == 'BASE' or options[:quiet]
         differ.call
@@ -148,7 +148,7 @@ module Subversion
     def diff_url(url, revision, user_options = {})
       options = {:quiet => false, :change => false}.merge! user_options
       differ = Proc.new do
-        Subversion.run("diff", (options[:change] ? "-c" : "-r"), revision, url)
+        Subversion.run("diff", (options[:change] ? "-c" : "-r"), (ENV['TM_SVN_DIFF_CMD'] ? "--diff-cmd=#{ENV['TM_SVN_DIFF_CMD']}" : ''), revision, url)
       end
       if options[:quiet]
         differ.call


### PR DESCRIPTION
The Subversion Bundle ships with TM2 doesn't support environment variable  TM_SVN_DIFF_CMD to use external difftool with --diff-cmd=foo.
This pull request just fix it.
